### PR TITLE
Render target first pass implementation

### DIFF
--- a/DMGSimpleUI/DMG/Elements/BaseUIElement.cs
+++ b/DMGSimpleUI/DMG/Elements/BaseUIElement.cs
@@ -11,7 +11,7 @@ public class BaseUIElement
     protected Vector2 _position;
     protected Rectangle _rect;
     protected Color _shade = Color.White;
-    protected Color _color;
+    public Color _color;
     protected SpriteFont _font;
     protected Vector2 _origin;
     protected int leftTextPadding;

--- a/DMGSimpleUI/DMG/Elements/DMGButton.cs
+++ b/DMGSimpleUI/DMG/Elements/DMGButton.cs
@@ -27,9 +27,9 @@ public class DMGButton: BaseUIElement
         _interactable = true;
     
         // ReSharper disable once PossibleLossOfFraction
-        screenWidthAdjustment = DMGUIGlobals.Bounds.X / 2 - t.Width ;
+        //screenWidthAdjustment = DMGUIGlobals.Bounds.X / 2 - t.Width ;
         // ReSharper disable once PossibleLossOfFraction
-        screenHeightAdjustment = DMGUIGlobals.Bounds.Y / 2 - (t.Height * 4.2);
+        //screenHeightAdjustment = DMGUIGlobals.Bounds.Y / 2 - (t.Height * 4.2);
         
         leftTextPadding = (int) (t.Width * .1);
         topleftTextPadding = (int) (t.Height *.34 );
@@ -48,9 +48,9 @@ public class DMGButton: BaseUIElement
         _interactable = true;
     
         // ReSharper disable once PossibleLossOfFraction
-        screenWidthAdjustment = DMGUIGlobals.Bounds.X / 2 - t.Width ;
+        //screenWidthAdjustment = DMGUIGlobals.Bounds.X / 2 - t.Width ;
         // ReSharper disable once PossibleLossOfFraction
-        screenHeightAdjustment = DMGUIGlobals.Bounds.Y / 2 - (t.Height * 4.2);
+        //screenHeightAdjustment = DMGUIGlobals.Bounds.Y / 2 - (t.Height * 4.2);
         
         leftTextPadding = (int) (t.Width * .1);
         topleftTextPadding = (int) (t.Height *.34 );
@@ -77,6 +77,7 @@ public class DMGButton: BaseUIElement
     public override void Update()
     {
         //if (!_interactable) return;
+       
         foreach (var e in _children)
         {
             e.Update();
@@ -94,6 +95,8 @@ public class DMGButton: BaseUIElement
         }
     }
 
+    
+    
     protected override void Click()
     {
         OnClick?.Invoke(this, EventArgs.Empty);

--- a/DMGSimpleUI/DMG/Management/DMGUIGlobals.cs
+++ b/DMGSimpleUI/DMG/Management/DMGUIGlobals.cs
@@ -12,6 +12,8 @@ public class DMGUIGlobals
     public static GraphicsDevice GraphicsDevice { get; set; }
     public static MouseState MouseState;
     public static MouseState LastMouseState;
+    private static KeyboardState _lastKeyboard;
+    private static KeyboardState _currentKeyboard;
     
     public static bool Clicked { get; set; }
     public static bool BeginDrag { get; set; }
@@ -27,5 +29,11 @@ public class DMGUIGlobals
         Clicked = (MouseState.LeftButton == ButtonState.Pressed) &&
                   (LastMouseState.LeftButton == ButtonState.Released);
         MouseCursor = new Rectangle(MouseState.Position, new Point(1, 1));
+        _lastKeyboard = _currentKeyboard;
+        _currentKeyboard = Keyboard.GetState();
+    }
+    public static bool IsKeyPressed(Keys key)
+    {
+        return _currentKeyboard.IsKeyDown(key) && _lastKeyboard.IsKeyUp(key);
     }
 }

--- a/DMGSimpleUI/DMG/Management/DMGUIGlobals.cs
+++ b/DMGSimpleUI/DMG/Management/DMGUIGlobals.cs
@@ -18,7 +18,7 @@ public class DMGUIGlobals
     public static bool Clicked { get; set; }
     public static bool BeginDrag { get; set; }
     public static Rectangle MouseCursor { get; set; }
-    // public static Vector2 CursorScaling { get; set; } 
+    
     public static void Update(GameTime gt)
     {
         TotalSeconds = (float) gt.ElapsedGameTime.TotalSeconds;
@@ -28,7 +28,6 @@ public class DMGUIGlobals
                      LastMouseState.LeftButton == ButtonState.Released);
         Clicked = (MouseState.LeftButton == ButtonState.Pressed) &&
                   (LastMouseState.LeftButton == ButtonState.Released);
-        //MouseCursor = new Rectangle(MouseState.Position, new Point(1, 1));
         MouseCursor = new Rectangle( MouseToCursorScaling(), new Point(1, 1));
         _lastKeyboard = _currentKeyboard;
         _currentKeyboard = Keyboard.GetState();

--- a/DMGSimpleUI/DMG/Management/DMGUIGlobals.cs
+++ b/DMGSimpleUI/DMG/Management/DMGUIGlobals.cs
@@ -18,7 +18,7 @@ public class DMGUIGlobals
     public static bool Clicked { get; set; }
     public static bool BeginDrag { get; set; }
     public static Rectangle MouseCursor { get; set; }
-    
+    // public static Vector2 CursorScaling { get; set; } 
     public static void Update(GameTime gt)
     {
         TotalSeconds = (float) gt.ElapsedGameTime.TotalSeconds;
@@ -28,10 +28,18 @@ public class DMGUIGlobals
                      LastMouseState.LeftButton == ButtonState.Released);
         Clicked = (MouseState.LeftButton == ButtonState.Pressed) &&
                   (LastMouseState.LeftButton == ButtonState.Released);
-        MouseCursor = new Rectangle(MouseState.Position, new Point(1, 1));
+        //MouseCursor = new Rectangle(MouseState.Position, new Point(1, 1));
+        MouseCursor = new Rectangle( MouseToCursorScaling(), new Point(1, 1));
         _lastKeyboard = _currentKeyboard;
         _currentKeyboard = Keyboard.GetState();
     }
+
+    private static Point MouseToCursorScaling()
+    {
+        var cursorPosition = MouseState.Position.ToVector2() * UIManager.CursorScaling;
+        return new Point((int)cursorPosition.X, (int)cursorPosition.Y);
+    }
+  
     public static bool IsKeyPressed(Keys key)
     {
         return _currentKeyboard.IsKeyDown(key) && _lastKeyboard.IsKeyUp(key);

--- a/DMGSimpleUI/DMG/Management/UIManager.cs
+++ b/DMGSimpleUI/DMG/Management/UIManager.cs
@@ -74,6 +74,7 @@ public class UIManager
         MainMenuSample.ScreenTransition += OnScreenTransition;
          
         AddUIAlertMessage("Welcome to DMG Simple UI Demo", Color.Aqua);
+        SetResolution(DMGUIGlobals.Bounds.X,DMGUIGlobals.Bounds.Y);
     }
     
     private void SetResolution(int height, int width)
@@ -139,16 +140,6 @@ public class UIManager
 
     public void Draw()
     {
-        // _dmgCanvas.Activate();
-        // DMGUIGlobals.SpriteBatch.Begin();
-        // _dmgCanvas.Draw(DMGUIGlobals.SpriteBatch);
-        // _drawActiveUi();
-        // DMGUIGlobals.SpriteBatch.DrawString(Font, $"Mouse: {DMGUIGlobals.MouseCursor.X} , {DMGUIGlobals.MouseCursor.Y}", new Vector2(DMGUIGlobals.Bounds.X - 150,DMGUIGlobals.Bounds.Y - 25), Color.AntiqueWhite);
-        // DMGUIGlobals.SpriteBatch.DrawString(Font, infoMessage.message, new Vector2( 150, DMGUIGlobals.Bounds.Y - 25), infoMessage.color);
-        //
-        // DMGUIGlobals.SpriteBatch.End();
-       
-        
         _dmgCanvas.Activate();
         DMGUIGlobals.SpriteBatch.Begin();
         {

--- a/DMGSimpleUI/DMG/Management/UIManager.cs
+++ b/DMGSimpleUI/DMG/Management/UIManager.cs
@@ -34,7 +34,7 @@ public class UIManager
     // Render Target items
     private readonly DMGCanvas _dmgCanvas;
     private readonly GraphicsDeviceManager _graphics;
-    public static Vector2 CursorScaling { get; set; } 
+    public static Vector2 CursorScaling { get; private set; } 
 
     public UIManager(Game game, GraphicsDeviceManager graphics, DMGUITheme theme)
     {
@@ -101,14 +101,18 @@ public class UIManager
 
         var r_target_width = _dmgCanvas.GetRenderTarget().Width;
         var display_mode_width = (float) _graphics.PreferredBackBufferWidth; //GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width; <- is this for fullscreen?
-
         var divided_width = r_target_width / display_mode_width;
         
         var r_target_height = _dmgCanvas.GetRenderTarget().Height;
         var display_mode_height = (float) _graphics.PreferredBackBufferHeight; //GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height; <- is this for fullscreen?
-        
         var divided_height = r_target_height / display_mode_height;
 
+       // BUG: This cursor scaling works well UNTIL we have excessive letterboxing
+       // at such time it starts stretching the coordinates to the real screen,
+       // not the rendered bit inside the letterboxing
+       // did some googling - not sure on how to solve this yet
+       // problem occurs for both vertical and horizontal letterboxing
+       
         CursorScaling = new Vector2(divided_width, divided_height);
         
         // CursorScaling = new Vector2(_dmgCanvas.GetRenderTarget().Width / (float) GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width,
@@ -150,8 +154,10 @@ public class UIManager
     {
         if (DMGUIGlobals.IsKeyPressed(Keys.F1)) SetResolution(1280, 720);
         if (DMGUIGlobals.IsKeyPressed(Keys.F2)) SetResolution(1920, 1080);
-        if (DMGUIGlobals.IsKeyPressed(Keys.F3)) SetResolution(640, 1080);
-        if (DMGUIGlobals.IsKeyPressed(Keys.F4)) SetFullScreen();
+        if (DMGUIGlobals.IsKeyPressed(Keys.F3)) SetResolution(1400, 900);
+        if (DMGUIGlobals.IsKeyPressed(Keys.F4)) SetResolution(800, 1280);
+        if (DMGUIGlobals.IsKeyPressed(Keys.F5)) SetResolution(1800, 480);
+        if (DMGUIGlobals.IsKeyPressed(Keys.F6)) SetFullScreen();
         
         _updateActiveUi();
         

--- a/DMGSimpleUI/DMG/Management/UIManager.cs
+++ b/DMGSimpleUI/DMG/Management/UIManager.cs
@@ -34,6 +34,7 @@ public class UIManager
     // Render Target items
     private readonly DMGCanvas _dmgCanvas;
     private readonly GraphicsDeviceManager _graphics;
+    public static Vector2 CursorScaling { get; set; } 
 
     public UIManager(Game game, GraphicsDeviceManager graphics, DMGUITheme theme)
     {
@@ -74,7 +75,8 @@ public class UIManager
         MainMenuSample.ScreenTransition += OnScreenTransition;
          
         AddUIAlertMessage("Welcome to DMG Simple UI Demo", Color.Aqua);
-        SetResolution(DMGUIGlobals.Bounds.X,DMGUIGlobals.Bounds.Y);
+        //SetResolution(DMGUIGlobals.Bounds.X,DMGUIGlobals.Bounds.Y);
+        SetResolution(480,360);
     }
     
     private void SetResolution(int height, int width)
@@ -84,6 +86,7 @@ public class UIManager
         _game.Window.IsBorderless = false;
         _graphics.ApplyChanges();
         _dmgCanvas.SetDestinationRectangle();
+        UpdateCursorScaling();
     }
     private void SetFullScreen()
     {
@@ -92,6 +95,24 @@ public class UIManager
         _game.Window.IsBorderless = true;
         _graphics.ApplyChanges();
         _dmgCanvas.SetDestinationRectangle();
+    }
+    private void UpdateCursorScaling()
+    {
+
+        var r_target_width = _dmgCanvas.GetRenderTarget().Width;
+        var display_mode_width = (float) _graphics.PreferredBackBufferWidth; //GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width; <- is this for fullscreen?
+
+        var divided_width = r_target_width / display_mode_width;
+        
+        var r_target_height = _dmgCanvas.GetRenderTarget().Height;
+        var display_mode_height = (float) _graphics.PreferredBackBufferHeight; //GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height; <- is this for fullscreen?
+        
+        var divided_height = r_target_height / display_mode_height;
+
+        CursorScaling = new Vector2(divided_width, divided_height);
+        
+        // CursorScaling = new Vector2(_dmgCanvas.GetRenderTarget().Width / (float) GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Width,
+        //     _dmgCanvas.GetRenderTarget().Height / (float) GraphicsAdapter.DefaultAdapter.CurrentDisplayMode.Height);
     }
     private void OnScreenTransition(DMGTransition transition)
     {

--- a/DMGSimpleUI/DMG/Management/UIManager.cs
+++ b/DMGSimpleUI/DMG/Management/UIManager.cs
@@ -13,25 +13,24 @@ public class UIManager
     private readonly List<BaseUIElement> _elements = new();
     
     private UIAlertMessage infoMessage = new UIAlertMessage{message = String.Empty, color = Color.White };
-
+   
     private Dictionary<int, UIAlertMessage> UIAlertMessages = new Dictionary<int, UIAlertMessage>();
     private int messageCount = 0;
     
     // UI Samples
     private MenuBarSample _menuBarSample;
     private MainMenuSample _mainMenuSample;
+    private SampleSceneNavigator _sampleSceneNavigator = new SampleSceneNavigator();
     
     // Delegate for active UI 
     private delegate void DrawActiveUI();
-
     private DrawActiveUI _drawActiveUi;
-
     private delegate void UpdateActiveUI();
-
     private UpdateActiveUI _updateActiveUi;
+    
     private Game _game;
     private DMGUITheme _theme;
-    
+
     public UIManager(Game game, DMGUITheme theme)
     {
         _game = game;
@@ -52,8 +51,14 @@ public class UIManager
         
         MenuBarSample.QuitGame += OnQuitGame;
         MainMenuSample.QuitGame += OnQuitGame;
+        MainMenuSample.ScreenTransition += OnScreenTransition;
          
         AddUIAlertMessage("Welcome to DMG Simple UI Demo", Color.Aqua);
+    }
+
+    private void OnScreenTransition(DMGTransition transition)
+    {
+        _sampleSceneNavigator.InitializeTransition(transition, _mainMenuSample, _menuBarSample);
     }
 
     private void OnQuitGame()
@@ -83,9 +88,12 @@ public class UIManager
         return e;
     }
 
-    public void Update()
+    public void Update(GameTime gameTime)
     {
         _updateActiveUi();
+        
+        if(_sampleSceneNavigator.TransitionActive())
+            _sampleSceneNavigator.Update(gameTime);
     }
 
     public void Draw()

--- a/DMGSimpleUI/DMG/Models/DMGCanvas.cs
+++ b/DMGSimpleUI/DMG/Models/DMGCanvas.cs
@@ -1,0 +1,48 @@
+using System;
+
+namespace DMGSimpleUI.DMG.Models;
+
+public class DMGCanvas
+{
+    private readonly RenderTarget2D _target;
+    private readonly GraphicsDevice _graphicsDevice;
+    private Rectangle _destinationRectangle;
+
+    public DMGCanvas(GraphicsDevice graphicsDevice, int width, int height)
+    {
+        _graphicsDevice = graphicsDevice;
+        _target = new(_graphicsDevice, width, height);
+    }
+
+    public void SetDestinationRectangle()
+    {
+        var screenSize = _graphicsDevice.PresentationParameters.Bounds;
+
+        var scaleX = (float)screenSize.Width / _target.Width;
+        var scaleY = (float)screenSize.Height / _target.Height;
+        var scale = Math.Min(scaleX, scaleY);
+
+        var newWidth = (int)(_target.Width * scale);
+        var newHeight = (int)(_target.Height * scale);
+
+        var posX = (screenSize.Width - newWidth) / 2;
+        var posY = (screenSize.Height - newHeight) / 2;
+
+        _destinationRectangle = new Rectangle(posX, posY, newWidth, newHeight);
+    }
+
+    public void Activate()
+    {
+        _graphicsDevice.SetRenderTarget(_target);
+        _graphicsDevice.Clear(Color.DarkGray);
+    }
+
+    public void Draw(SpriteBatch spriteBatch)
+    {
+        _graphicsDevice.SetRenderTarget(null);
+        _graphicsDevice.Clear(Color.Black);
+        spriteBatch.Begin();
+        spriteBatch.Draw(_target, _destinationRectangle, Color.White);
+        spriteBatch.End();
+    }
+}

--- a/DMGSimpleUI/DMG/Models/DMGCanvas.cs
+++ b/DMGSimpleUI/DMG/Models/DMGCanvas.cs
@@ -34,15 +34,15 @@ public class DMGCanvas
     public void Activate()
     {
         _graphicsDevice.SetRenderTarget(_target);
-        _graphicsDevice.Clear(Color.DarkGray);
+        _graphicsDevice.Clear(Color.MonoGameOrange);
     }
 
     public void Draw(SpriteBatch spriteBatch)
     {
-        _graphicsDevice.SetRenderTarget(null);
-        _graphicsDevice.Clear(Color.Black);
-        spriteBatch.Begin();
+        // _graphicsDevice.SetRenderTarget(null);
+        // _graphicsDevice.Clear(Color.Black);
+        //spriteBatch.Begin();
         spriteBatch.Draw(_target, _destinationRectangle, Color.White);
-        spriteBatch.End();
+        //spriteBatch.End();
     }
 }

--- a/DMGSimpleUI/DMG/Models/DMGCanvas.cs
+++ b/DMGSimpleUI/DMG/Models/DMGCanvas.cs
@@ -31,6 +31,10 @@ public class DMGCanvas
         _destinationRectangle = new Rectangle(posX, posY, newWidth, newHeight);
     }
 
+    public RenderTarget2D GetRenderTarget()
+    {
+        return _target;
+    }
     public void Activate()
     {
         _graphicsDevice.SetRenderTarget(_target);
@@ -39,10 +43,6 @@ public class DMGCanvas
 
     public void Draw(SpriteBatch spriteBatch)
     {
-        // _graphicsDevice.SetRenderTarget(null);
-        // _graphicsDevice.Clear(Color.Black);
-        //spriteBatch.Begin();
         spriteBatch.Draw(_target, _destinationRectangle, Color.White);
-        //spriteBatch.End();
     }
 }

--- a/DMGSimpleUI/DMG/Models/DMGScene.cs
+++ b/DMGSimpleUI/DMG/Models/DMGScene.cs
@@ -1,0 +1,7 @@
+namespace DMGSimpleUI.DMG.Models;
+
+public abstract class DMGScene
+{
+    public abstract void Update();
+    public abstract void Draw();
+}

--- a/DMGSimpleUI/DMG/Models/DMGTransition.cs
+++ b/DMGSimpleUI/DMG/Models/DMGTransition.cs
@@ -1,8 +1,13 @@
+using System.Collections.Generic;
+using DMGSimpleUI.DMG.Elements;
+
 namespace DMGSimpleUI.DMG.Models;
 
 public class DMGTransition
 {
     public DMGTransitionType TransitionType { get; set; }
+    public BaseUIElement _uiElement;
+    //public List<BaseUIElement> _elements = new();
     public float duration;
     public bool isDone;
 }

--- a/DMGSimpleUI/DMG/Samples/MainMenuSample.cs
+++ b/DMGSimpleUI/DMG/Samples/MainMenuSample.cs
@@ -6,7 +6,7 @@ using DMGSimpleUI.DMG.Models;
 
 namespace DMGSimpleUI.DMG.Samples;
 
-public class MainMenuSample
+public class MainMenuSample : DMGScene
 {
     public static Action QuitGame;
 
@@ -51,7 +51,7 @@ public class MainMenuSample
         QuitGame?.Invoke();
     }
 
-    public void Update()
+    public override void Update()
     {
         foreach (var item in _elements)
         {
@@ -59,7 +59,7 @@ public class MainMenuSample
         }
     }
 
-    public void Draw()
+    public override void Draw()
     {
         foreach (var item in _elements)
         {

--- a/DMGSimpleUI/DMG/Samples/MainMenuSample.cs
+++ b/DMGSimpleUI/DMG/Samples/MainMenuSample.cs
@@ -9,36 +9,50 @@ namespace DMGSimpleUI.DMG.Samples;
 public class MainMenuSample : DMGScene
 {
     public static Action QuitGame;
+    public static Action<DMGTransition> ScreenTransition;
 
     private Texture2D backgroundTexture;
     private readonly List<BaseUIElement> _elements = new();
+
+    private DMGPanel background;
     
     public MainMenuSample(DMGUITheme theme)
     {
         backgroundTexture = DMGUIGlobals.Content.Load<Texture2D>("panelbg64x");
         var t = DMGUIGlobals.Content.Load<Texture2D>("whitebutton128x32"); 
         
-        var bg = new DMGPanel(backgroundTexture, new(0, 0),
+        background = new DMGPanel(backgroundTexture, new(0, 0),
             DMGUIGlobals.UIFont,theme,
             new Point(DMGUIGlobals.Bounds.X, DMGUIGlobals.Bounds.Y), "BACKGROUND PANEL..");
 
         // ReSharper disable once PossibleLossOfFraction
         var H_CENTER = (float)(DMGUIGlobals.Bounds.Y / 2) ;
         var V_CENTER = (float)DMGUIGlobals.Bounds.X / 2;
-        bg.AddChild(new DMGPanel(backgroundTexture, new(540, 325),
+        background.AddChild(new DMGPanel(backgroundTexture, new(540, 325),
             DMGUIGlobals.UIFont,theme,
             new Point(200, 256), "MAIN MENU PANEL"));
-        bg.AddChild( new DMGButton(t, new Vector2(V_CENTER -64, H_CENTER),
+        background.AddChild( new DMGButton(t, new Vector2(V_CENTER -64, H_CENTER),
             theme,
-            DMGUIGlobals.UIFont, "PLAY GAME"));
-        bg.AddChild(new DMGButton(t, new Vector2(V_CENTER -64, H_CENTER +35),
+            DMGUIGlobals.UIFont, "PLAY GAME")).OnClick += OnPlayGame;
+        background.AddChild(new DMGButton(t, new Vector2(V_CENTER -64, H_CENTER +35),
             theme,
             DMGUIGlobals.UIFont, "SETTINGS")).OnClick += OnSettings;
-        bg.AddChild(new DMGButton(t, new Vector2(V_CENTER -64, H_CENTER +70),
+        background.AddChild(new DMGButton(t, new Vector2(V_CENTER -64, H_CENTER +70),
             theme,
             DMGUIGlobals.UIFont, "QUIT GAME")).OnClick += OnQuit;
         
-        _elements.Add(bg);
+        _elements.Add(background);
+    }
+
+    private void OnPlayGame(object sender, EventArgs e)
+    {
+        var tran = new DMGTransition()
+        {
+            TransitionType = DMGTransitionType.FADE_OUT,
+            duration = 2f,
+            _uiElement = background,
+        };
+        ScreenTransition?.Invoke(tran);
     }
 
     private void OnSettings(object sender, EventArgs e)

--- a/DMGSimpleUI/DMG/Samples/MenuBarSample.cs
+++ b/DMGSimpleUI/DMG/Samples/MenuBarSample.cs
@@ -6,7 +6,7 @@ using DMGSimpleUI.DMG.Models;
 
 namespace DMGSimpleUI.DMG.Samples;
 
-public class MenuBarSample
+public class MenuBarSample : DMGScene
 {
     public static Action QuitGame;
     private readonly List<BaseUIElement> _elements = new();
@@ -56,7 +56,7 @@ public class MenuBarSample
     }
 
     
-    public void Update()
+    public override void Update()
     {
         foreach (var item in _elements)
         {
@@ -64,7 +64,7 @@ public class MenuBarSample
         }
     }
 
-    public void Draw()
+    public override void Draw()
     {
         foreach (var item in _elements)
         {

--- a/DMGSimpleUI/DMG/Samples/SampleSceneNavigator.cs
+++ b/DMGSimpleUI/DMG/Samples/SampleSceneNavigator.cs
@@ -1,25 +1,59 @@
+using System;
+using DMGSimpleUI.DMG.Management;
 using DMGSimpleUI.DMG.Models;
+using MonoGame.Extended;
+using MonoGame.Extended.Sprites;
+using MonoGame.Extended.Tweening;
 
 namespace DMGSimpleUI.DMG.Samples;
 
 public class SampleSceneNavigator
 {
-    public DMGTransition transition;
+    private DMGTransition _transition;
+    private DMGScene _outGoingScene;
+    private DMGScene _incomingScene;
+
+    private float _transitionHalfwayTime = 0f;
     
-    public void Update()
+    private bool _transitionHalfway = false;
+    private bool _transitionComplete = false;
+    private readonly Tweener _tweener = new Tweener();
+    
+    public void InitializeTransition(DMGTransition transition, DMGScene outScene, DMGScene inScene)
     {
-        // foreach (var item in _elements)
-        // {
-        //     item.Update();
-        // }
+        _transition = transition;
+        _outGoingScene = outScene;
+        _incomingScene = inScene;
+        
+        _transitionHalfway = false;
+        _transitionComplete = false;
+
+        _transitionHalfwayTime = transition.duration / 2;
+        
+        var item = transition._uiElement;
+        
+        // near as i can tell tweening colors is not supported?
+        
+        _tweener.TweenTo(target: item, expression: ui => item._color, toValue: new Color(0, 0, 0, 255),
+                duration: _transition.duration, delay: .1f)
+            .Easing(EasingFunctions.QuinticIn)
+            .OnEnd(tween => _transitionComplete = true);
+    }
+
+    public bool TransitionActive()
+    {
+        return !_transitionComplete;
+    }
+    public void Update(GameTime gameTime)
+    {
+        if(!_transitionComplete)
+            _tweener.Update(gameTime.GetElapsedSeconds());
     }
 
     public void Draw()
     {
-        // foreach (var item in _elements)
-        // {
-        //     item.Draw();
-        // }
+        if(!_transitionComplete)
+            _transition._uiElement.Draw();
     } 
     
 }

--- a/DMGSimpleUI/DMG/Samples/SampleSceneNavigator.cs
+++ b/DMGSimpleUI/DMG/Samples/SampleSceneNavigator.cs
@@ -1,6 +1,25 @@
+using DMGSimpleUI.DMG.Models;
+
 namespace DMGSimpleUI.DMG.Samples;
 
 public class SampleSceneNavigator
 {
+    public DMGTransition transition;
+    
+    public void Update()
+    {
+        // foreach (var item in _elements)
+        // {
+        //     item.Update();
+        // }
+    }
+
+    public void Draw()
+    {
+        // foreach (var item in _elements)
+        // {
+        //     item.Draw();
+        // }
+    } 
     
 }

--- a/DMGSimpleUI/DMGSimpleUI.csproj
+++ b/DMGSimpleUI/DMGSimpleUI.csproj
@@ -12,6 +12,7 @@
         <ApplicationIcon>Icon.ico</ApplicationIcon>
     </PropertyGroup>
     <ItemGroup>
+        <PackageReference Include="MonoGame.Extended.Tweening" Version="3.8.0" />
         <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.1.303"/>
         <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.1.303"/>
     </ItemGroup>

--- a/DMGSimpleUI/Game1.cs
+++ b/DMGSimpleUI/Game1.cs
@@ -24,13 +24,12 @@ public class Game1 : Game
  
     protected override void Initialize()
     {
-        DMGUIGlobals.Bounds = new(1280, 720);
         DMGUIGlobals.Content = Content;
         
-        _graphics.PreferredBackBufferWidth = DMGUIGlobals.Bounds.X;
-        _graphics.PreferredBackBufferHeight =  DMGUIGlobals.Bounds.Y;
+        _theme = SampleThemes.GetFireTheme();
+        _uiManager = new UIManager(this,_graphics,_theme);
         
-        _graphics.ApplyChanges();
+        //_graphics.ApplyChanges();
 
         base.Initialize();
     }
@@ -38,12 +37,7 @@ public class Game1 : Game
     protected override void LoadContent()
     {
         _spriteBatch = new SpriteBatch(GraphicsDevice);
-
         DMGUIGlobals.SpriteBatch = _spriteBatch;
-        
-        _theme = SampleThemes.GetFireTheme();
-        _uiManager = new UIManager(this,_theme);
-
     }
 
     protected override void Update(GameTime gameTime)
@@ -60,13 +54,14 @@ public class Game1 : Game
 
     protected override void Draw(GameTime gameTime)
     {
-        GraphicsDevice.Clear(_theme.backgroundColor);
+        _uiManager.Draw();
+        //GraphicsDevice.Clear(_theme.backgroundColor);
 
-       _spriteBatch.Begin();
-       {
-           _uiManager.Draw();
-       }
-       _spriteBatch.End();
+       // _spriteBatch.Begin();
+       // {
+       //     _uiManager.Draw();
+       // }
+       // _spriteBatch.End();
 
         base.Draw(gameTime);
     }

--- a/DMGSimpleUI/Game1.cs
+++ b/DMGSimpleUI/Game1.cs
@@ -53,7 +53,7 @@ public class Game1 : Game
             Exit();
 
         DMGUIGlobals.Update(gameTime);
-        _uiManager.Update();
+        _uiManager.Update(gameTime);
         
         base.Update(gameTime);
     }


### PR DESCRIPTION
Allows to set a Render Target resolution where the game may be rendered at for example 640x480 but then using RenderTarget2D rendered to a screen resolution of 1980x1080.

Supports letterboxing for resolutions that distort the overall view.

There is a bug where resolutions that result in extensive letterboxing cause the cursor scaling to become slowly out of sync depending on the horizontal or vertical scaling that is going on (in the same axis as the letterboxing).